### PR TITLE
Release: hab-client v1.0.2

### DIFF
--- a/lib/Hab.js
+++ b/lib/Hab.js
@@ -243,7 +243,7 @@ class Hab {
             if (execOptions.wait) {
                 return new Promise((resolve, reject) => {
                     process.on('exit', code => {
-                        if (code == 0) {
+                        if (code == 0 || execOptions.nullOnError) {
                             resolve();
                         } else {
                             reject(code);
@@ -263,7 +263,7 @@ class Hab {
                         });
 
                         process.on('exit', code => {
-                            if (code == 0) {
+                            if (code == 0 || execOptions.nullOnError) {
                                 resolve(output);
                             } else {
                                 reject({ output, code });


### PR DESCRIPTION
- fix: resolve promises for processes with nonzero exit code if nullOnError is enabled